### PR TITLE
Fix link underline offsets

### DIFF
--- a/components/link.js
+++ b/components/link.js
@@ -18,7 +18,12 @@ export default function Link({
   href = href ?? attrs.href;
 
   const classNames = (attrs.className ?? '').split(' ');
-  classNames.push('cursor-pointer', theme.linkColor);
+
+  classNames.push(
+    'cursor-pointer',
+    'underline-thickness-thin',
+    theme.linkColor
+  );
 
   if (underline) {
     classNames.push('underline');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,8 +56,11 @@ module.exports = {
       sans: ['Helvetica', 'Arial', 'sans-serif'],
     },
     underlineOffset: {
-      sm: '1px',
-      md: '2px',
+      sm: '0.08em',
+      md: '0.12em',
+    },
+    underlineThickness: {
+      thin: '2px',
     },
     extend: {
       transitionProperty: {


### PR DESCRIPTION
## Actual
<img width="635" alt="image" src="https://user-images.githubusercontent.com/2770198/152650237-936f44a0-c3fd-4f49-b0ee-74bae5b3761c.png">

## Expected
<img width="635" alt="image" src="https://user-images.githubusercontent.com/2770198/152650253-c08021de-ebd8-4d99-a33e-efd08b20ab7f.png">

Previously, the offset classes weren't being included in production builds because of tailwind class purging. The concatenation of classes is an anti-pattern for tailwind purging because it needs to find the *entire* class name to avoid the purge. This refactor keeps the entire class name intact.

There was also some stylistic differences between underlines in safari and chrome which have been tweaked to be more consistent here.